### PR TITLE
feat: Resolve as "project-root relative" path for GitHub annot (#9)

### DIFF
--- a/src/sarif2gha/github_annotation_encoder.py
+++ b/src/sarif2gha/github_annotation_encoder.py
@@ -8,16 +8,29 @@
 # (at your option) any later version.
 
 import re
+from pathlib import PureWindowsPath
 
 from sarif2gha.analysis_result import AnalysisResult, Severity
 
 
 class GitHubAnnotationEncoder:
+    _normalized_project_root_dir: str
+
+    def __init__(self, project_root_dir_path: str):
+        """
+        Constructor.
+
+        Args:
+            project_root_dir_path: Project root dir to resolve paths in SARIF.
+        """
+        self._normalized_project_root_dir = self._normalize_dir(project_root_dir_path)
+
     """Encoder for GitHub Annotation style string from analysis data."""
     def encode(self, analysis_result: AnalysisResult) -> str:
         """Encode GitHub Annotation string from AnalysisResult instance."""
         encoded_str = f"::{self._encode_severity(analysis_result.severity)} "
-        encoded_str += f"file={self._encode_property_str(analysis_result.file)}"
+        file = self._resolve_as_project_root_relative_path(analysis_result.file)
+        encoded_str += f"file={self._encode_property_str(file)}"
         if analysis_result.start_line is not None:
             if analysis_result.start_line < 0:
                 raise ValueError(
@@ -99,3 +112,22 @@ class GitHubAnnotationEncoder:
         """Escape given str by escape_dict."""
         re_obj = re.compile("|".join(re.escape(key) for key in escape_dict))
         return re_obj.sub(lambda m: escape_dict[m.group(0)], src)
+
+    def _normalize_dir(self, dir: str) -> str:
+        """Normalize given dir string.
+
+        * Path delimiters are unified into '/'
+        * Starting with '/' for absolute path, even if for Windows path ('/C:/foo/bar/')
+        * Ending with '/'
+        """
+        path = PureWindowsPath(dir)
+        normalized_dir = path.as_posix()
+        if path.is_absolute() and not normalized_dir.startswith('/'):
+            normalized_dir = '/' + normalized_dir
+        return normalized_dir.rstrip('/') + '/'
+
+    def _resolve_as_project_root_relative_path(self, path: str) -> str:
+        """Resolve path as project root relative if project root dir is specified."""
+        if self._normalized_project_root_dir is None:
+            return path
+        return path.removeprefix(self._normalized_project_root_dir)

--- a/src/sarif2gha/github_annotation_encoder.py
+++ b/src/sarif2gha/github_annotation_encoder.py
@@ -23,7 +23,11 @@ class GitHubAnnotationEncoder:
         Args:
             project_root_dir_path: Project root dir to resolve paths in SARIF.
         """
-        self._normalized_project_root_dir = self._normalize_dir(project_root_dir_path)
+        self._normalized_project_root_dir = (
+            self._normalize_dir(project_root_dir_path)
+            if project_root_dir_path
+            else None
+        )
 
     """Encoder for GitHub Annotation style string from analysis data."""
     def encode(self, analysis_result: AnalysisResult) -> str:
@@ -125,6 +129,9 @@ class GitHubAnnotationEncoder:
         * Starting with '/' for absolute path, even if for Windows path ('/C:/foo/bar/')
         * Ending with '/'
         """
+        # Just return given value if it is None or empty string.
+        if not dir:
+            return dir
         path = PureWindowsPath(dir)
         normalized_dir = path.as_posix()
         if path.is_absolute() and not normalized_dir.startswith('/'):
@@ -133,6 +140,6 @@ class GitHubAnnotationEncoder:
 
     def _resolve_as_project_root_relative_path(self, path: str) -> str:
         """Resolve path as project root relative if project root dir is specified."""
-        if self._normalized_project_root_dir is None:
+        if not self._normalized_project_root_dir:
             return path
         return path.removeprefix(self._normalized_project_root_dir)

--- a/src/sarif2gha/github_annotation_encoder.py
+++ b/src/sarif2gha/github_annotation_encoder.py
@@ -28,6 +28,11 @@ class GitHubAnnotationEncoder:
     """Encoder for GitHub Annotation style string from analysis data."""
     def encode(self, analysis_result: AnalysisResult) -> str:
         """Encode GitHub Annotation string from AnalysisResult instance."""
+        if '\\' in analysis_result.file:
+            raise ValueError(
+                f"analysis_result.file must use forward slashes, "
+                f"got: {analysis_result.file!r}"
+            )
         encoded_str = f"::{self._encode_severity(analysis_result.severity)} "
         file = self._resolve_as_project_root_relative_path(analysis_result.file)
         encoded_str += f"file={self._encode_property_str(file)}"

--- a/tests/test_github_annotation_encoder.py
+++ b/tests/test_github_annotation_encoder.py
@@ -13,13 +13,8 @@ from sarif2gha.analysis_result import AnalysisResult, Severity
 from sarif2gha.github_annotation_encoder import GitHubAnnotationEncoder
 
 
-@pytest.fixture()
-def encoder():
-    """Construct test target encoder instance."""
-    return GitHubAnnotationEncoder()
-
 @pytest.mark.parametrize(
-    "analysis_result, expected_str",
+    "analysis_result, project_root_dir, expected_str",
     [
         pytest.param(
             AnalysisResult(
@@ -32,6 +27,7 @@ def encoder():
                 title='Warning title',
                 message='Main message'
             ),
+            '',
             '::warning '
             'file=src/foo.py,line=8,col=3,endLine=9,endColumn=80,'
             'title=Warning title'
@@ -49,8 +45,9 @@ def encoder():
                 title='disallow unused variables',
                 message="'x' is assigned a value but never used."
             ),
+            'C:\\dev\\sarif\\sarif-tutorials',
             "::error "
-            "file=/C%3A/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js,line=1,col=5,"
+            "file=samples/Introduction/simple-example.js,line=1,col=5,"
             "title=disallow unused variables"
             "::'x' is assigned a value but never used.",
             id='error_without_any_ends'
@@ -69,8 +66,9 @@ def encoder():
                     "in the insecure function 'eval'."
                 )
             ),
+            'Beyond-basics',
             "::notice "
-            "file=Beyond-basics/bad-eval.py,line=3,"
+            "file=bad-eval.py,line=3,"
             "title=PY2335"
             "::Use of tainted variable 'expr' %0Ain the insecure function 'eval'.",
             id='notice_with_escape'
@@ -78,7 +76,11 @@ def encoder():
     ]
 )
 
-def test_github_annotation_encoder(encoder, analysis_result, expected_str):
+def test_github_annotation_encoder(
+        analysis_result,
+        project_root_dir,
+        expected_str):
     """Parameterized tests for typical usages of GitHubAnnotationEncoder."""
+    encoder = GitHubAnnotationEncoder(project_root_dir)
     encoded_str = encoder.encode(analysis_result)
     assert encoded_str == expected_str


### PR DESCRIPTION
Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encoder accepts a project root directory and displays file paths relative to that root for clearer, shorter annotations.

* **Bug Fixes**
  * Paths are normalized to use forward slashes and resolved against the configured root; malformed paths using backslashes now raise an explicit error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->