### PR TITLE
feat: Output GitHub Annotation string to stdout. (#6)

### DIFF
--- a/src/sarif2gha/stdout_writer.py
+++ b/src/sarif2gha/stdout_writer.py
@@ -12,6 +12,14 @@ import sys
 
 class StdoutWriter:
     def write(self, src_str: str):
+        """Write the given string to stdout with a trailing newline.
+
+        This method always appends '\\n' at the end of the output,
+        similar to the built-in print() function.
+
+        Args:
+            src_str: A string to write.
+        """
         sys.stdout.write(f"{src_str}\n")
         # Flushing will help log processing by GitHub.
         sys.stdout.flush()

--- a/src/sarif2gha/stdout_writer.py
+++ b/src/sarif2gha/stdout_writer.py
@@ -13,3 +13,6 @@ import sys
 class StdoutWriter:
     def write(self, src_str: str):
         sys.stdout.write(f"{src_str}\n")
+        # Flushing will help log processing by GitHub.
+        sys.stdout.flush()
+

--- a/src/sarif2gha/stdout_writer.py
+++ b/src/sarif2gha/stdout_writer.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Copyright (C) 2026 Minoru Sekine
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+import sys
+
+
+class StdoutWriter:
+    def write(self, src_str: str):
+        sys.stdout.write(f"{src_str}\n")

--- a/tests/test_stdout_writer.py
+++ b/tests/test_stdout_writer.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Copyright (C) 2026 Minoru Sekine
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from unittest.mock import patch
+
+import pytest
+
+from sarif2gha.stdout_writer import StdoutWriter
+
+
+@pytest.mark.parametrize(
+    "src_str",
+    [
+        (
+            '::warning '
+            'file=src/foo.py,line=8,col=3,endLine=9,endColumn=80,'
+            'title=Warning title'
+            '::Main message'
+        ),
+        (
+            "::error "
+            "file=samples/Introduction/simple-example.js,line=1,col=5,"
+            "title=disallow unused variables"
+            "::'x' is assigned a value but never used."
+        )
+    ]
+)
+
+
+def test_stdout_writer(src_str):
+    writer = StdoutWriter()
+    with patch('sys.stdout.write') as mock_write:
+        writer.write(src_str)
+
+        expected_str = src_str + '\n'
+        mock_write.assert_called_once_with(expected_str)

--- a/tests/test_stdout_writer.py
+++ b/tests/test_stdout_writer.py
@@ -28,6 +28,35 @@ from sarif2gha.stdout_writer import StdoutWriter
             "file=samples/Introduction/simple-example.js,line=1,col=5,"
             "title=disallow unused variables"
             "::'x' is assigned a value but never used."
+        ),
+        (
+            "::notice "
+            "file=bad-eval.py,line=3,"
+            "title=PY2335"
+            "::Use of tainted variable 'expr' %0Ain the insecure function 'eval'."
+        ),
+        (
+            ''
+        ),
+        (
+            "::notice "
+            "::very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "very very very very very very very very "
+            "long string test"
         )
     ]
 )

--- a/tests/test_stdout_writer.py
+++ b/tests/test_stdout_writer.py
@@ -7,8 +7,6 @@
 # by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-from unittest.mock import patch
-
 import pytest
 
 from sarif2gha.stdout_writer import StdoutWriter
@@ -62,11 +60,10 @@ from sarif2gha.stdout_writer import StdoutWriter
 )
 
 
-def test_stdout_writer(src_str):
+def test_stdout_writer(capsys, src_str):
     """Tests for typical usage of StdoutWriter."""
     writer = StdoutWriter()
-    with patch('sys.stdout.write') as mock_write:
-        writer.write(src_str)
+    writer.write(src_str)
 
-        expected_str = src_str + '\n'
-        mock_write.assert_called_once_with(expected_str)
+    captured = capsys.readouterr()
+    assert captured.out == src_str + '\n'

--- a/tests/test_stdout_writer.py
+++ b/tests/test_stdout_writer.py
@@ -34,6 +34,7 @@ from sarif2gha.stdout_writer import StdoutWriter
 
 
 def test_stdout_writer(src_str):
+    """Tests for typical usage of StdoutWriter."""
     writer = StdoutWriter()
     with patch('sys.stdout.write') as mock_write:
         writer.write(src_str)


### PR DESCRIPTION
Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a simple stdout writer that prints messages with a single trailing newline and flushes immediately for deterministic, unbuffered output.

* **Tests**
  * Added tests confirming output matches the original message plus one newline across empty, typical, warning/error/notice-style, and very long messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->